### PR TITLE
Disable asset helper tenancy to enforce explicit use of tenant_asset(…

### DIFF
--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -133,7 +133,7 @@ return [
          * disable asset() helper tenancy and explicitly use tenant_asset() calls in places
          * where you want to use tenant-specific assets (product images, avatars, etc).
          */
-        'asset_helper_tenancy' => true,
+        'asset_helper_tenancy' => false,
     ],
 
     /*


### PR DESCRIPTION
…) for tenant-specific assets